### PR TITLE
Support user supplied socket paths for restricted environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ call, and other things.
 
 The shell script (or any program) needs to call the `beam_notify` program
 supplied by this library. The message is passed via commandline arguments or
-environment variables.
+environment variables (see `:report_env` option).
 
 Since `beam_notify` needs to know how to connect to the appropriate
 `BEAMNotify` GenServer (there may be more than one), the shell script must pass
@@ -87,9 +87,9 @@ Start up Elixir with `iex -S mix`:
 iex> us = self()
 #PID<0.204.0>
 
-# Start a BEAMNotify GenServer. The dispatcher function just sends a tuple
-# with the arguments and environment passed in from the shell script.
-iex> BEAMNotify.start_link(name: "sulu", dispatcher: &send(us, {&1, &2}))
+# Start a BEAMNotify GenServer. The dispatcher function sends a tuple with the
+# arguments and environment passed in from the shell script.
+iex> BEAMNotify.start_link(name: "sulu", report_env: true, dispatcher: &send(us, {&1, &2}))
 {:ok, #PID<0.211.0>}
 
 # Run the shell script. We're doing this from Elixir, but you

--- a/c_src/beam_notify.c
+++ b/c_src/beam_notify.c
@@ -94,11 +94,111 @@ static void encode_args(ei_x_buff *buff, int argc, char *argv[])
     }
 }
 
+static int inplace_string_to_argv(char *str, char **argv, int max_args)
+{
+    int argc = 0;
+    char *c = str;
+#define STATE_SPACE 0
+#define STATE_TOKEN 1
+#define STATE_QUOTED_TOKEN 2
+    int state = STATE_SPACE;
+    max_args--; // leave room for final null
+    while (*c != '\0') {
+        switch (state) {
+        case STATE_SPACE:
+            if (isspace(*c))
+                break;
+            else if (*c == '"') {
+                *argv = c + 1;
+                state = STATE_QUOTED_TOKEN;
+            } else {
+                *argv = c;
+                state = STATE_TOKEN;
+            }
+            break;
+        case STATE_TOKEN:
+            if (isspace(*c)) {
+                *c = '\0';
+                argv++;
+                argc++;
+                state = STATE_SPACE;
+
+                if (argc == max_args)
+                    break;
+            }
+            break;
+        case STATE_QUOTED_TOKEN:
+            if (*c == '"') {
+                *c = '\0';
+                argv++;
+                argc++;
+                state = STATE_SPACE;
+
+                if (argc == max_args)
+                    break;
+            }
+            break;
+        }
+        c++;
+    }
+
+    if (state != STATE_SPACE)
+        argc++;
+    argv = NULL;
+
+    return argc;
+}
+
+struct beam_notify_options {
+    char *path;
+};
+
+static int parse_arguments(int argc, char *argv[], struct beam_notify_options *bn)
+{
+    int opt;
+
+    while ((opt = getopt(argc, argv, "p:")) != -1) {
+        switch (opt) {
+        case 'p':
+            bn->path = optarg;
+            break;
+        default:
+            return -1;
+        }
+    }
+
+    return optind;
+}
+
 int main(int argc, char *argv[])
 {
+    struct beam_notify_options bn;
+    memset(&bn, 0, sizeof(bn));
+
+    // Parse options from $BEAM_NOTIFY_OPTIONS. If insufficient, check the commandline
     char *options = getenv("BEAM_NOTIFY_OPTIONS");
-    if (options == NULL)
-        errx(EXIT_FAILURE, "BEAM_NOTIFY_OPTIONS must be set");
+    if (options) {
+        #define MAX_OPTIONS 3
+        char *options_argv[MAX_OPTIONS + 1];
+        options_argv[0] = ""; // "Program name"
+        int option_argc = inplace_string_to_argv(options, &options_argv[1], MAX_OPTIONS);
+        if (parse_arguments(option_argc + 1, options_argv, &bn) < 0)
+            errx(EXIT_FAILURE, "$BEAM_NOTIFY_OPTIONS is corrupt or invalid");
+    }
+    if (bn.path == NULL) {
+        int processed_argc = parse_arguments(argc, argv, &bn);
+        if (processed_argc < 0)
+            errx(EXIT_FAILURE, "Invalid arguments or $BEAM_NOTIFY_OPTIONS's value was lost");
+
+        if (bn.path == NULL)
+            errx(EXIT_FAILURE, "Missing socket path. Either use $BEAM_NOTIFY_OPTIONS or pass -p <path>");
+
+        // Adjust argc, argv so that they start after our arguments
+        argc = argc - processed_argc + 1;
+        argv += processed_argc - 1;
+        *argv[0] = '\0'; // new program name
+
+    }
 
     int fd = socket(AF_UNIX, SOCK_DGRAM, 0);
     if (fd < 0)
@@ -107,7 +207,7 @@ int main(int argc, char *argv[])
     struct sockaddr_un addr;
     memset(&addr, 0, sizeof(addr));
     addr.sun_family = AF_UNIX;
-    strncpy(addr.sun_path, options, sizeof(addr.sun_path) - 1);
+    strncpy(addr.sun_path, bn.path, sizeof(addr.sun_path) - 1);
 
     if (connect(fd, (struct sockaddr *)&addr, sizeof(addr)) == -1)
         err(EXIT_FAILURE, "connect");

--- a/lib/beam_notify.ex
+++ b/lib/beam_notify.ex
@@ -36,16 +36,8 @@ defmodule BEAMNotify do
   """
   @spec start_link(options()) :: GenServer.on_start()
   def start_link(options) do
-    name = gen_server_name(options[:name])
+    name = options |> name_from_options() |> gen_server_name()
     GenServer.start_link(__MODULE__, options, name: name)
-  end
-
-  defp gen_server_name(nil) do
-    gen_server_name(:global)
-  end
-
-  defp gen_server_name(name) do
-    Module.concat(__MODULE__, name)
   end
 
   @doc """
@@ -140,6 +132,14 @@ defmodule BEAMNotify do
     _ = File.rm(state.socket_path)
   end
 
+  defp gen_server_name(name) do
+    Module.concat(__MODULE__, name)
+  end
+
+  defp name_from_options(options) do
+    Keyword.get(options, :name, :unnamed)
+  end
+
   defp null_dispatcher(args, env) do
     Logger.warn("beam_notify called with no dispatcher: #{inspect(args)}, #{inspect(env)}")
   end
@@ -149,6 +149,7 @@ defmodule BEAMNotify do
   end
 
   defp socket_path(options) do
-    Path.join(System.tmp_dir!(), "beam_notify-#{options[:name]}")
+    name = "beam_notify-" <> to_string(name_from_options(options))
+    Path.join(System.tmp_dir!(), name)
   end
 end

--- a/lib/beam_notify.ex
+++ b/lib/beam_notify.ex
@@ -4,8 +4,6 @@ defmodule BEAMNotify do
 
   @moduledoc """
   Send a message to the BEAM from a shell script
-
-
   """
 
   @typedoc """
@@ -26,12 +24,19 @@ defmodule BEAMNotify do
   * `:dispatcher` - a function to call when a notification comes in
   * `:path` - the path to use for the named socket. A path in the system
      temporary directory is the default.
-  * `:environment` - TBD
+  * `:report_env` - set to `true` to report environment variables in addition
+     to commandline argument. Defaults to `false`
   * `:recbuf` - receive buffer size. If you're sending a particular large
      amount of data and getting errors from `:erlang.binary_to_term(data)`, try
      making this bigger. Defaults to 8192.
   """
-  @type options() :: [name: binary() | atom(), path: Path.t(), dispatcher: dispatcher()]
+  @type options() :: [
+          name: binary() | atom(),
+          path: Path.t(),
+          dispatcher: dispatcher(),
+          report_env: boolean(),
+          recbuf: non_neg_integer()
+        ]
 
   @doc """
   Start the BEAMNotify message receiver
@@ -152,7 +157,15 @@ defmodule BEAMNotify do
   end
 
   defp options_to_cmdline(options) do
-    ["-p", socket_path(options)]
+    ["-p", socket_path(options)] ++ report_env_arg(options)
+  end
+
+  defp report_env_arg(options) do
+    if Keyword.get(options, :report_env) do
+      ["-e"]
+    else
+      []
+    end
   end
 
   defp quote_string(s) do

--- a/lib/beam_notify.ex
+++ b/lib/beam_notify.ex
@@ -179,7 +179,8 @@ defmodule BEAMNotify do
   defp socket_path(options) do
     case Keyword.get(options, :path) do
       nil ->
-        name = "beam_notify-" <> to_string(name_from_options(options))
+        safe_name = name_from_options(options) |> :erlang.phash2() |> Integer.to_string()
+        name = "beam_notify-" <> safe_name
         Path.join(System.tmp_dir!(), name)
 
       path ->

--- a/test/beam_notify_test.exs
+++ b/test/beam_notify_test.exs
@@ -25,6 +25,16 @@ defmodule BEAMNotifyTest do
     assert_receive {["hello", "nameless"], %{}}
   end
 
+  test "explicit socket path" do
+    us = self()
+    pid = start_supervised!({BEAMNotify, path: "test_socket", dispatcher: &send(us, {&1, &2})})
+
+    env = BEAMNotify.env(pid)
+    {"", 0} = System.cmd(env["BEAM_NOTIFY"], ["hello", "explicit", "path"], env: env)
+
+    assert_receive {["hello", "explicit", "path"], %{}}
+  end
+
   test "sending a message via a script", context do
     pid = start_supervised!(beam_notify_child_spec(context))
 
@@ -48,5 +58,24 @@ defmodule BEAMNotifyTest do
     bin_path = BEAMNotify.bin_path()
 
     assert bin_path == env["BEAM_NOTIFY"]
+  end
+
+  test "sending a message via commandline args", context do
+    pid = start_supervised!(beam_notify_child_spec(context))
+    script = "#{BEAMNotify.bin_path()} #{BEAMNotify.env(pid)["BEAM_NOTIFY_OPTIONS"]} -- hello"
+
+    # BEAM_NOTIFY_OPTIONS not set
+    {"", 0} = System.cmd("/bin/sh", ["-c", script])
+    assert_receive {["hello"], %{}}
+
+    # BEAM_NOTIFY_OPTIONS set to an empty string (easy mistake when trying to unset a variable)
+    {"", 0} = System.cmd("/bin/sh", ["-c", script], env: %{"BEAM_NOTIFY_OPTIONS" => ""})
+
+    assert_receive {["hello"], %{}}
+
+    # BEAM_NOTIFY_OPTIONS set to a string with spaces
+    {"", 0} = System.cmd("/bin/sh", ["-c", script], env: %{"BEAM_NOTIFY_OPTIONS" => "   "})
+
+    assert_receive {["hello"], %{}}
   end
 end

--- a/test/beam_notify_test.exs
+++ b/test/beam_notify_test.exs
@@ -15,6 +15,16 @@ defmodule BEAMNotifyTest do
     assert_receive {["hello", "from", "a", "c", "program"], %{}}
   end
 
+  test "nameless use" do
+    us = self()
+    pid = start_supervised!({BEAMNotify, dispatcher: &send(us, {&1, &2})})
+
+    env = BEAMNotify.env(pid)
+    {"", 0} = System.cmd(env["BEAM_NOTIFY"], ["hello", "nameless"], env: env)
+
+    assert_receive {["hello", "nameless"], %{}}
+  end
+
   test "sending a message via a script", context do
     pid = start_supervised!(beam_notify_child_spec(context))
 


### PR DESCRIPTION
Restricted shell environments are those which sanitize the OS environment
and effectively prevent `$BEAM_NOTIFY_OPTIONS` from being passed. As a
result, the user needs to find some other way to pass the socket path to
the `beam_notify` binary. This adds the `:path` option to starting the
`BEAMNotify` GenServer and the `-p` option to `beam_notify` so that they
can hardcode a path or do whatever makes sense for their situation.

A side effect of this change is that `$BEAM_NOTIFY_OPTIONS` now mirrors the
commandline parameters. When in doubt, users can look at it for a hint.