### PR TITLE
Support setting socket permissions through :mode param

### DIFF
--- a/lib/beam_notify.ex
+++ b/lib/beam_notify.ex
@@ -24,6 +24,8 @@ defmodule BEAMNotify do
   * `:dispatcher` - a function to call when a notification comes in
   * `:path` - the path to use for the named socket. A path in the system
      temporary directory is the default.
+  * `:mode` - the permissions to apply to the socket. Should be an octal number
+     eg: 0o660 for read/write owner/group, no access to everyone else
   * `:report_env` - set to `true` to report environment variables in addition
      to commandline argument. Defaults to `false`
   * `:recbuf` - receive buffer size. If you're sending a particular large
@@ -33,6 +35,7 @@ defmodule BEAMNotify do
   @type options() :: [
           name: binary() | atom(),
           path: Path.t(),
+          mode: non_neg_integer(),
           dispatcher: dispatcher(),
           report_env: boolean(),
           recbuf: non_neg_integer()
@@ -95,6 +98,7 @@ defmodule BEAMNotify do
     socket_path = socket_path(options)
     dispatcher = Keyword.get(options, :dispatcher, &null_dispatcher/2)
     recbuf = Keyword.get(options, :recbuf, 8192)
+    mode = Keyword.get(options, :mode)
 
     # Blindly try to remove an old file just in case it exists from a previous run
     _ = File.rm(socket_path)
@@ -108,6 +112,8 @@ defmodule BEAMNotify do
         {:ip, {:local, socket_path}},
         {:recbuf, recbuf}
       ])
+
+    if mode, do: File.chmod(socket_path, mode)
 
     state = %{
       socket_path: socket_path,

--- a/test/beam_notify_test.exs
+++ b/test/beam_notify_test.exs
@@ -37,6 +37,14 @@ defmodule BEAMNotifyTest do
     assert_receive {["hello", "explicit", "path"], %{}}
   end
 
+  test "explicit socket permissions" do
+    # Unusual mode
+    mode = 0o711
+    pid = start_supervised!({BEAMNotify, path: "test_socket", mode: mode})
+
+    assert mode == Bitwise.band(File.stat!("test_socket").mode(), 0o777)
+  end
+
   test "sending a message via a script", context do
     pid = start_supervised!(beam_notify_child_spec(context))
 


### PR DESCRIPTION
Hi, can you consider this for inclusion upstream. I am using beam_notify in an embedded situation, but I need various other subsystems to talk to the socket. The elixir app is not running as root. I achieve this by having sockets have group permissions. However, the defaults for my beam_notifier socket end up 755 and so I don't have write access to the rest of the group.

This change allows setting an explicit mode on the created socket, (recommend something like 0o660 or 0o770). I've not created a default, but I guess one of the above options could be a sensible default if we wanted to reduce "world" permissions by default?