### PR TITLE
Test with Elixir 1.14, drop Elixir 1.9, fix credo warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,87 +1,60 @@
-version: 2
+version: 2.1
 
-defaults: &defaults
-  working_directory: ~/repo
-  environment:
-    LC_ALL: C.UTF-8
-
-install_hex_rebar: &install_hex_rebar
-  run:
-    name: Install hex and rebar
-    command: |
-      mix local.hex --force
-      mix local.rebar --force
-
-install_system_deps: &install_system_deps
-  run:
-    name: Install system dependencies
-    command: |
-        apk add build-base
+latest: &latest
+  pattern: "^1.14.3-erlang-25.*$"
 
 jobs:
-  build_elixir_1_12_otp_24:
+  build-test:
+    parameters:
+      tag:
+        type: string
     docker:
-      - image: hexpm/elixir:1.12.3-erlang-24.1.2-alpine-3.14.2
-    <<: *defaults
+      - image: hexpm/elixir:<< parameters.tag >>
+    working_directory: ~/repo
+    environment:
+      LC_ALL: C.UTF-8
     steps:
+      - run:
+          name: Install system dependencies
+          command: apk add --no-cache build-base
       - checkout
-      - <<: *install_hex_rebar
-      - <<: *install_system_deps
+      - run:
+          name: Install hex and rebar
+          command: |
+            mix local.hex --force
+            mix local.rebar --force
       - restore_cache:
           keys:
-            - v1-mix-cache-{{ checksum "mix.lock" }}
+            - v1-mix-cache-<< parameters.tag >>-{{ checksum "mix.lock" }}
       - run: mix deps.get
-      - run: mix format --check-formatted
-      - run: mix deps.unlock --check-unused
-      - run: mix compile --warnings-as-errors
-      - run: mix docs
-      - run: mix hex.build
       - run: mix test
-      - run: mix dialyzer
+      - when:
+          condition:
+            matches: { <<: *latest, value: << parameters.tag >> }
+          steps:
+            - run: mix format --check-formatted
+            - run: mix deps.unlock --check-unused
+            - run: mix docs
+            - run: mix hex.build
+            - run: mix credo -a --strict
+            - run: mix dialyzer
       - save_cache:
-          key: v1-mix-cache-{{ checksum "mix.lock" }}
+          key: v1-mix-cache-<< parameters.tag >>-{{ checksum "mix.lock" }}
           paths:
             - _build
             - deps
 
-  build_elixir_1_11_otp_23:
-    docker:
-      - image: hexpm/elixir:1.11.4-erlang-23.3.4-alpine-3.13.3
-    <<: *defaults
-    steps:
-      - checkout
-      - <<: *install_hex_rebar
-      - <<: *install_system_deps
-      - run: mix deps.get
-      - run: mix test
-
-  build_elixir_1_10_otp_23:
-    docker:
-      - image: hexpm/elixir:1.10.4-erlang-23.3.4-alpine-3.13.3
-    <<: *defaults
-    steps:
-      - checkout
-      - <<: *install_hex_rebar
-      - <<: *install_system_deps
-      - run: mix deps.get
-      - run: mix test
-
-  build_elixir_1_9_otp_22:
-    docker:
-      - image: hexpm/elixir:1.9.4-erlang-22.3.4.18-alpine-3.13.3
-    <<: *defaults
-    steps:
-      - checkout
-      - <<: *install_hex_rebar
-      - <<: *install_system_deps
-      - run: mix deps.get
-      - run: mix test
-
 workflows:
-  version: 2
-  build_test:
+  checks:
     jobs:
-      - build_elixir_1_12_otp_24
-      - build_elixir_1_11_otp_23
-      - build_elixir_1_10_otp_23
-      - build_elixir_1_9_otp_22
+      - build-test:
+          name: << matrix.tag >>
+          matrix:
+            parameters:
+              tag: [
+                1.14.3-erlang-25.3-alpine-3.17.2,
+                1.13.4-erlang-24.3.4-alpine-3.15.3,
+                1.12.3-erlang-24.3.4-alpine-3.15.3,
+                1.11.4-erlang-23.3.4.13-alpine-3.15.3,
+                1.10.4-erlang-23.3.4-alpine-3.13.3
+              ]

--- a/.credo.exs
+++ b/.credo.exs
@@ -1,0 +1,17 @@
+# .credo.exs
+%{
+  configs: [
+    %{
+      name: "default",
+      strict: true,
+      checks: [
+        {Credo.Check.Refactor.MapInto, false},
+        {Credo.Check.Warning.LazyLogging, false},
+        {Credo.Check.Readability.LargeNumbers, only_greater_than: 86400},
+        {Credo.Check.Readability.ParenthesesOnZeroArityDefs, parens: true},
+        {Credo.Check.Readability.Specs, tags: []},
+        {Credo.Check.Readability.StrictModuleLayout, tags: []}
+      ]
+    }
+  ]
+}

--- a/lib/beam_notify.ex
+++ b/lib/beam_notify.ex
@@ -1,10 +1,10 @@
 defmodule BEAMNotify do
-  use GenServer
-  require Logger
-
   @moduledoc """
   Send a message to the BEAM from a shell script
   """
+  use GenServer
+
+  require Logger
 
   @typedoc """
   Callback for dispatching notifications
@@ -158,7 +158,7 @@ defmodule BEAMNotify do
   end
 
   defp options_to_env(options) do
-    bn_options = options_to_cmdline(options) |> Enum.map(&quote_string/1) |> Enum.join(" ")
+    bn_options = options_to_cmdline(options) |> Enum.map_join(" ", &quote_string/1)
     %{"BEAM_NOTIFY" => bin_path(), "BEAM_NOTIFY_OPTIONS" => bn_options}
   end
 

--- a/lib/beam_notify.ex
+++ b/lib/beam_notify.ex
@@ -154,7 +154,7 @@ defmodule BEAMNotify do
   end
 
   defp null_dispatcher(args, env) do
-    Logger.warn("beam_notify called with no dispatcher: #{inspect(args)}, #{inspect(env)}")
+    Logger.warning("beam_notify called with no dispatcher: #{inspect(args)}, #{inspect(env)}")
   end
 
   defp options_to_env(options) do

--- a/mix.exs
+++ b/mix.exs
@@ -65,7 +65,7 @@ defmodule BEAMNotify.MixProject do
 
   defp dialyzer() do
     [
-      flags: [:race_conditions, :unmatched_returns, :error_handling, :underspecs]
+      flags: [:missing_return, :extra_return, :unmatched_returns, :error_handling, :underspecs]
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule BEAMNotify.MixProject do
     [
       app: :beam_notify,
       version: @version,
-      elixir: "~> 1.9",
+      elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       compilers: [:elixir_make | Mix.compilers()],
       make_targets: ["all"],


### PR DESCRIPTION
- Fix Elixir 1.15 Logger warning
- ci: test with Elixir 1.14, drop 1.9
